### PR TITLE
Additional testing functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor/*
 events_consumer
 metrics_consumer
-
+coverage.out
+coverfragment.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,33 @@
+# vim: noai:ts=2:sw=2:ft=yaml:
+language: minimal
+
 git:
   depth: 1
-language: go
-go:
-- 1.9.7
+
 sudo: required
-dist: xenial
+
 services:
-- docker
+  - docker
+
 env:
   global:
-  - ELASTIC_VERSION=6.0.1
-  - QDROUTERD_VERSION=1.7.0
-  - secure: biIvVwFaTdbJythty17sCNsKKU7R9m4cusvV/jiOTwPMTaXuxMgC4XWFsvwFcLO0Nze2RewswxOg5i6hkLpqPTcZLR9GZdXpRG24nuwImHPpgdbpwX35kUnnK4jLY5kOcwndTVHZoqpetxejBxgtKo839dhA7sfFKx4HI+xti3FJvjZgdc/7A2QABGG5wu08XZDo50p1vx7BR9IxgEnK7i34Gq9qXbeeltYChqXIZ4M1rCpevWgvUcvgtyRkcNAtEXjiVTzb+XocHvyjuLBAwu5xzg5xPjiLHJvo3CvxdPb3VsYNHFmxv1g0vJUMR5dELLydhmcIcWAJQGUcDm3FnYQbd8EEuRHvefSubjG+aagNc/8rDAP0yIvTGpIZ9mwDb5x/ps0urOOGLC34ik33sYz2IGlazn2cM4RaGv78TPgibEdQEBCyY0E0zuKo3QejOlG0qkqKF3joZfS90PuKBBPWSEgFrXp357BRBtz/e45FfrwOUwqDYTlj0ivJ99Cnam+GUnlgkn0a2aVQhwAE9XTtrj+Q8JtnhUeTIskN+/OTsYFn8wVWePRK9LhoosFsOoMzA0QQTRn+O2EAN8V5LWY44ghJkGoLNMrvla4Lwc/oPyMqQvDbwJRXeoJ3Fz38TIcTw6HnxRj5DiBlidbl6GxOy/9K8iohkDQ6Z5OzvuI=
+    - ELASTIC_VERSION=6.0.1
+    - QDROUTERD_VERSION=1.7.0
+    - secure: biIvVwFaTdbJythty17sCNsKKU7R9m4cusvV/jiOTwPMTaXuxMgC4XWFsvwFcLO0Nze2RewswxOg5i6hkLpqPTcZLR9GZdXpRG24nuwImHPpgdbpwX35kUnnK4jLY5kOcwndTVHZoqpetxejBxgtKo839dhA7sfFKx4HI+xti3FJvjZgdc/7A2QABGG5wu08XZDo50p1vx7BR9IxgEnK7i34Gq9qXbeeltYChqXIZ4M1rCpevWgvUcvgtyRkcNAtEXjiVTzb+XocHvyjuLBAwu5xzg5xPjiLHJvo3CvxdPb3VsYNHFmxv1g0vJUMR5dELLydhmcIcWAJQGUcDm3FnYQbd8EEuRHvefSubjG+aagNc/8rDAP0yIvTGpIZ9mwDb5x/ps0urOOGLC34ik33sYz2IGlazn2cM4RaGv78TPgibEdQEBCyY0E0zuKo3QejOlG0qkqKF3joZfS90PuKBBPWSEgFrXp357BRBtz/e45FfrwOUwqDYTlj0ivJ99Cnam+GUnlgkn0a2aVQhwAE9XTtrj+Q8JtnhUeTIskN+/OTsYFn8wVWePRK9LhoosFsOoMzA0QQTRn+O2EAN8V5LWY44ghJkGoLNMrvla4Lwc/oPyMqQvDbwJRXeoJ3Fz38TIcTw6HnxRj5DiBlidbl6GxOy/9K8iohkDQ6Z5OzvuI=
+
+# setup dependencies required for testing
 before_install:
-- docker pull docker.elastic.co/elasticsearch/elasticsearch:$ELASTIC_VERSION
-- docker run -p 9200:9200 --name elastic -p 9300:9300 -e "discovery.type=single-node"
-  -d docker.elastic.co/elasticsearch/elasticsearch:$ELASTIC_VERSION
-- docker pull quay.io/interconnectedcloud/qdrouterd:$QDROUTERD_VERSION
-- docker run -p 5672:5672 -d quay.io/interconnectedcloud/qdrouterd:$QDROUTERD_VERSION
-- sleep 10
-- docker pull centos:7
-- docker run -eCOVERALLS_TOKEN -uroot --network host -it --volume $PWD:/go/src/github.com/redhat-service-assurance/smart-gateway:z
-  --workdir /go/src/github.com/redhat-service-assurance/smart-gateway centos:7 /bin/sh
-  -c 'sh ./run_tests.sh'
+  - docker pull docker.elastic.co/elasticsearch/elasticsearch:$ELASTIC_VERSION
+  - docker run -p 9200:9200 --name elastic -p 9300:9300 -e "discovery.type=single-node" -d docker.elastic.co/elasticsearch/elasticsearch:$ELASTIC_VERSION
+  - docker pull quay.io/interconnectedcloud/qdrouterd:$QDROUTERD_VERSION
+  - docker run -p 5672:5672 -d quay.io/interconnectedcloud/qdrouterd:$QDROUTERD_VERSION
+  - docker pull centos:7
+
+# execute unit testing and code coverage
 install:
-- go get -u github.com/golang/dep/...
-- "$GOPATH/bin/dep ensure -v --vendor-only"
+  - docker run -eCOVERALLS_TOKEN -uroot --network host -it --volume $PWD:/go/src/github.com/redhat-service-assurance/smart-gateway:z --workdir /go/src/github.com/redhat-service-assurance/smart-gateway centos:7 /bin/sh -c 'sh ./run_tests.sh'
+
+# functional testing (validate it works)
 script:
-- docker build --tag redhat-service-assurance/smart_gateway:latest .
-- docker images
+  - docker build --tag redhat-service-assurance/smart_gateway:latest .
+  - docker images

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,83 @@
+#!/bin/sh
+# original source: https://raw.githubusercontent.com/streadway/amqp/master/pre-commit
+
+GOFMT_OK=1
+GOLINT_OK=1
+GOVET_OK=1
+
+# TODO: uncomment each of these tests during future pull-requests with
+#       resolving code changes
+main() {
+    mv_vendor_out
+#    run_gofmt
+#    run_golint
+    mv_vendor_in
+#    run_govet
+    check_results
+}
+
+local_go_version_is_latest_stable() {
+  go version | grep -q $LATEST_STABLE_SUPPORTED_GO_VERSION
+}
+
+log_error() {
+  echo "$*" 1>&2
+}
+
+mv_vendor_out() {
+    mv ./vendor/ /tmp/
+}
+
+mv_vendor_in() {
+    mv /tmp/vendor ./
+}
+
+check_results() {
+    if [[ "$GOFMT_OK" == "1" && "$GOLINT_OK" == "1" && "$GOVET_OK" == "1" ]]
+    then
+        echo "Formatting, Linting, and Vetting all returned OK."
+        exit 0
+    else
+        echo "One of Formatting, Linting, or Vetting is invalid. Check logs for more information."
+        exit 1
+    fi
+}
+
+run_gofmt() {
+  GOFMT_FILES=$(gofmt -l .)
+  if [ -n "$GOFMT_FILES" ]
+  then
+    log_error "gofmt failed for the following files:
+$GOFMT_FILES
+
+please run 'gofmt -w .' on your changes before committing."
+    GOFMT_OK=0
+  fi
+}
+
+run_golint() {
+  GOLINT_ERRORS=$(golint ./... | grep -v "Id should be")
+  if [ -n "$GOLINT_ERRORS" ]
+  then
+    log_error "golint failed for the following reasons:
+$GOLINT_ERRORS
+
+please run 'golint ./...' on your changes before committing."
+    GOLINT_OK=0
+  fi
+}
+
+run_govet() {
+  GOVET_ERRORS=$(go vet ./... 2>&1)
+  if [ -n "$GOVET_ERRORS" ]
+  then
+    log_error "go vet failed for the following reasons:
+$GOVET_ERRORS
+
+please run 'go tool vet ./*.go' on your changes before committing."
+    GOVET_OK=0
+  fi
+}
+
+main
+# vim: set ft=sh:ts=2:sw=2:noai:


### PR DESCRIPTION
    Adds additional code coverage to perform Golang format, linting, and
    vetting functionality via the pre-commit script. The current code does
    not pass these tests, and will need to be cleaned up in additional
    pull requests.
    
    Adds a separate call out to unit testing and makes sure the script can
    exit appropriately. Prior to changes in the run_tests.sh script, unit
    tests could fail, but would not trigger a Travis-CI failure.
    
    Cleans up the implementation of the Coveralls code as well, adds some
    fun comments, and overall makes the testing more robust. It has
    already started to indentify some areas of the code that need work.
    
    I have done local testing of each of the testing steps with enough
    localized code changes to validate that the testing should complete
    successfully once all failed testing results in a passing grade.
