### PR TITLE
Don't act like a bitcoin miner in Events mode

### DIFF
--- a/internal/pkg/events/events.go
+++ b/internal/pkg/events/events.go
@@ -251,8 +251,6 @@ func StartEvents() {
 			continue // priority channel
 		case status := <-amqpEventServer.GetStatus():
 			applicationHealth.QpidRouterState = status
-		default:
-			//no activity
 		}
 	}
 }


### PR DESCRIPTION
When running a Smart Gateway in Events mode, the CPU would run at a high
level when idling (not processing events). After some profiling with pprof
it was identified that the CPU was hanging in a case loop with a default that
wasn't doing any processing (thus not blocking).

Thanks to Chris Sibbitt and Aaron Smith for the help pointing out issue.

Closes #54