### PR TITLE
Update Gopkg.toml for latest vendoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -175,7 +175,8 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:f92bb8613c0405d38ea5c84ad793fa0e3f594d8078129e6cd2c95c496276d9a1"
+  branch = "go1"
+  digest = "1:8891472a79c8ba147f22c847f6ee30a6fc17be2542b74511f69fbb98c2295772"
   name = "qpid.apache.org"
   packages = [
     "amqp",
@@ -183,7 +184,7 @@
     "proton",
   ]
   pruneopts = "UT"
-  revision = "b25d21e6779a011e972a5f00e433e2034b793da1"
+  revision = "7bf92569070b69a52dc8ff2cf0c2635e9d5bbf3a"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,8 +43,8 @@ ignored = ["github.com/redhat-service-assurance/smart-gateway"]
   branch = "master"
 
 [[constraint]]
-  revision = "b25d21e6779a011e972a5f00e433e2034b793da1"
   name = "qpid.apache.org"
+  branch = "go1"
 
 [prune]
   go-tests = true

--- a/build/test-framework/pre-commit
+++ b/build/test-framework/pre-commit
@@ -4,6 +4,7 @@
 GOFMT_OK=1
 GOLINT_OK=1
 GOVET_OK=1
+DEPCHECK_OK=1
 
 # TODO: uncomment each of these tests during future pull-requests with
 #       resolving code changes
@@ -29,12 +30,12 @@ mv_vendor_in() {
 }
 
 check_results() {
-    if [[ "$GOFMT_OK" == "1" && "$GOLINT_OK" == "1" && "$GOVET_OK" == "1" ]]
+    if [[ "$GOFMT_OK" == "1" && "$GOLINT_OK" == "1" && "$GOVET_OK" == "1" && "$DEPCHECK_OK" == "1" ]]
     then
-        echo "Formatting, Linting, and Vetting all returned OK."
+        echo "Formatting, Linting, Vetting, and vendor check all returned OK."
         exit 0
     else
-        echo "One of Formatting, Linting, or Vetting is invalid. Check logs for more information."
+        echo "One of Formatting, Linting, Vetting, or vendor check is invalid. Check logs for more information."
         exit 1
     fi
 }
@@ -72,6 +73,18 @@ $GOVET_ERRORS
 
 please run 'go tool vet ./*.go' on your changes before committing."
     GOVET_OK=0
+  fi
+}
+
+run_dep_check() {
+  DEPCHECK_ERRORS=$(dep check)
+  if [ -n "$DEPCHECK_ERRORS" ]
+  then
+    log_error "dep check failed for the following reasons:
+$DEPCHECK_ERRORS
+
+please run 'dep check' on your changes before committing."
+    DEPCHECK_OK=0
   fi
 }
 


### PR DESCRIPTION
While working through upstream and downstream build process
I noted that our downstream imports were not actually getting
updated like I thought. While reviewing this, I noted that our
Gopkg.toml (and Gopkg.lock) are out of date for the vendoring that
would be getting done in the downstream.

Updating the vendoring here to get everything back in sync